### PR TITLE
If in an admin view, don't get page content

### DIFF
--- a/src/GravityServiceProvider.php
+++ b/src/GravityServiceProvider.php
@@ -61,6 +61,10 @@ class GravityServiceProvider extends ServiceProvider
 
         if (Schema::hasTable('page_content')) {
             view()->composer('*', function ($view) {
+                if (str_contains($view->getName(), 'gravity::')) {
+                    return;
+                }
+
                 $content = PageContent::getPageContent($view->getName())->all();
 
                 $pageNameParts = explode('.', $view->getName());


### PR DESCRIPTION
Adding the `->all()` broke admin pages as `$content` would hold the view name and not fetch page content.